### PR TITLE
Fix importing workouts from HealthKit

### DIFF
--- a/OutRun/Models/HealthKit/HealthQueryManager.swift
+++ b/OutRun/Models/HealthKit/HealthQueryManager.swift
@@ -71,8 +71,9 @@ enum HealthQueryManager {
                         }
                         completeIfAppropriate()
                         samples.forEach { (workout) in
+                            count += 1
+
                             guard let queryObject = HKWorkoutQueryObject(workout) else {
-                                count += 1
                                 completeIfAppropriate()
                                 return
                             }
@@ -81,7 +82,6 @@ enum HealthQueryManager {
                                 HealthQueryManager.getAndAttatchSteps(to: queryObject) {
                                     // not fully implemented
                                     //HealthQueryManager.getAndAttachHeartRate(to: queryObject) {
-                                        count += 1
                                         completeIfAppropriate()
                                     //}
                                 }


### PR DESCRIPTION
Resolves #20 

The count wasn't being updated when `getAndAttachRoute` or `getAndAttachSteps` fails.
Moving it outside the loop ensures that it is updated properly, regardless of inner blocks failing.

Need to understand why the route isn't being imported correctly, however this should resolve the issue with an infinite loading spinner being displayed. (Getting a printed error of `Error - could not parse HKSample to HKWorkoutRoute`)