### PR TITLE
Add heart rate support

### DIFF
--- a/OutRun.xcodeproj/project.pbxproj
+++ b/OutRun.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		22FEA0AF24CDD7B50007CA9C /* DiskStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FEA0AE24CDD7B50007CA9C /* DiskStorage.swift */; };
 		22FEA0B124CDDFF80007CA9C /* CustomByteFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FEA0B024CDDFF80007CA9C /* CustomByteFormatting.swift */; };
 		22FEA0B324CDE31E0007CA9C /* DebugController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FEA0B224CDE31E0007CA9C /* DebugController.swift */; };
+		2895C50E2527308700DB5079 /* HeartRateStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2895C50D2527308700DB5079 /* HeartRateStatsView.swift */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_OutRun.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_OutRun.framework */; };
 /* End PBXBuildFile section */
 
@@ -347,6 +348,7 @@
 		22FEA0AE24CDD7B50007CA9C /* DiskStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskStorage.swift; sourceTree = "<group>"; };
 		22FEA0B024CDDFF80007CA9C /* CustomByteFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomByteFormatting.swift; sourceTree = "<group>"; };
 		22FEA0B224CDE31E0007CA9C /* DebugController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugController.swift; sourceTree = "<group>"; };
+		2895C50D2527308700DB5079 /* HeartRateStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartRateStatsView.swift; sourceTree = "<group>"; };
 		8C0699EE439FF3DC5E16B8E0 /* Pods-OutRun.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OutRun.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OutRun/Pods-OutRun.debug.xcconfig"; sourceTree = "<group>"; };
 		C1C8D965F1351F85D4E4F35D /* Pods-OutRun.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OutRun.release.xcconfig"; path = "Pods/Target Support Files/Pods-OutRun/Pods-OutRun.release.xcconfig"; sourceTree = "<group>"; };
 		D2DC1601B9458B3FC1788F0E /* Pods_OutRun.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OutRun.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -749,6 +751,7 @@
 				22CBB44C2303FF5100DDA2E0 /* DistanceStatsView.swift */,
 				22CBB44E2303FF6800DDA2E0 /* TimeStatsView.swift */,
 				22CBB4502303FF7200DDA2E0 /* SpeedStatsView.swift */,
+				2895C50D2527308700DB5079 /* HeartRateStatsView.swift */,
 			);
 			path = Detail;
 			sourceTree = "<group>";
@@ -1162,6 +1165,7 @@
 				222632AC24B24FF80017517E /* ShareManager.swift in Sources */,
 				22B6CF5722CA0814002D2FB0 /* AppDelegate.swift in Sources */,
 				22FEA0A724CDA3FF0007CA9C /* ClosedRange.swift in Sources */,
+				2895C50E2527308700DB5079 /* HeartRateStatsView.swift in Sources */,
 				2230925C24D6F39700A3F636 /* WorkoutBuilderComponent.swift in Sources */,
 				22C1108424532E36009ACE81 /* WorkoutMapImageQueue.swift in Sources */,
 				2226A3BD240BF9AD00FF7A94 /* ProgressViewController.swift in Sources */,

--- a/OutRun/Controllers/Workout/WorkoutMapViewController.swift
+++ b/OutRun/Controllers/Workout/WorkoutMapViewController.swift
@@ -141,7 +141,6 @@ class WorkoutMapViewController: MapViewControllerWithConatinerView, LabelledDiag
         
         segementedControl.snp.makeConstraints { (make) in
             make.left.right.top.equalTo(containerView.safeAreaLayoutGuide).inset(spacing)
-            make.height.equalTo(30)
         }
         diagramView.snp.makeConstraints { (make) in
             make.left.right.bottom.equalTo(containerView.safeAreaLayoutGuide).inset(spacing)

--- a/OutRun/Controllers/Workout/WorkoutViewController.swift
+++ b/OutRun/Controllers/Workout/WorkoutViewController.swift
@@ -101,6 +101,7 @@ class WorkoutViewController: DetailViewController {
                 let distanceStatsView = DistanceStatsView(stats: stats)
                 let timeStatsView = TimeStatsView(stats: stats)
                 let speedStatsView = SpeedStatsView(stats: stats)
+                let heartRateStatsView = HeartRateStatsView(stats: stats)
                 let energyStatsView = EnergyStatsView(stats: stats)
                 let routeStatsView = RouteStatsView(controller: self, workout: workout, stats: stats)
                 let deleteView = DeleteWorkoutView(controller: self, workout: workout)
@@ -136,6 +137,7 @@ class WorkoutViewController: DetailViewController {
                 self.contentView.addSubview(distanceStatsView)
                 self.contentView.addSubview(timeStatsView)
                 self.contentView.addSubview(speedStatsView)
+                self.contentView.addSubview(heartRateStatsView)
                 self.contentView.addSubview(editView)
                 self.contentView.addSubview(deleteView)
                 
@@ -163,7 +165,7 @@ class WorkoutViewController: DetailViewController {
                 }
                 
                 var firstActionView: UIView?
-                var lastView: UIView?
+                var lastView: UIView = speedStatsView
                 
                 self.contentView.addSubview(appleHealthView)
                 
@@ -174,51 +176,28 @@ class WorkoutViewController: DetailViewController {
                 
                 firstActionView = appleHealthView
                 
-                if stats.hasRouteSamples && stats.hasEnergyValue {
-                    
-                    self.contentView.addSubview(energyStatsView)
-                    self.contentView.addSubview(routeStatsView)
-                    
-                    energyStatsView.snp.makeConstraints { (make) in
-                        make.left.right.equalToSuperview()
-                        make.top.equalTo(speedStatsView.snp.bottom).offset(20)
-                    }
-                    routeStatsView.snp.makeConstraints { (make) in
-                        make.left.right.equalToSuperview()
-                        make.top.equalTo(energyStatsView.snp.bottom).offset(20)
-                    }
-                    
-                    lastView = routeStatsView
-                    
-                } else if stats.hasRouteSamples {
-                    
-                    self.contentView.addSubview(routeStatsView)
-                    
-                    routeStatsView.snp.makeConstraints { (make) in
-                        make.left.right.equalToSuperview()
-                        make.top.equalTo(speedStatsView.snp.bottom).offset(20)
-                    }
-                    
-                    lastView = routeStatsView
-                    
-                } else if stats.hasEnergyValue {
-                    
-                    self.contentView.addSubview(energyStatsView)
-                    
-                    energyStatsView.snp.makeConstraints { (make) in
-                        make.left.right.equalToSuperview()
-                        make.top.equalTo(speedStatsView.snp.bottom).offset(20)
-                    }
-                    
-                    lastView = energyStatsView
-                    
-                } else {
-                    
-                    lastView = speedStatsView
-                    
-                }
+                var dynamicViews : [UIView] = []
                 
-                if (workout.comment.value != nil || workout.isUserModified.value), let lastView = lastView, let firstActionView = firstActionView {
+                if stats.hasEnergyValue {
+                    dynamicViews.append(energyStatsView)
+                }
+                if stats.hasHeartRateData {
+                    dynamicViews.append(heartRateStatsView)
+                }
+                if stats.hasRouteSamples {
+                    dynamicViews.append(routeStatsView)
+                }
+
+                for view in dynamicViews {
+                    self.contentView.addSubview(view)
+                    view.snp.makeConstraints { make in
+                        make.left.right.equalToSuperview()
+                        make.top.equalTo(lastView.snp.bottom).offset(20)
+                    }
+                    lastView = view
+                }
+
+                if (workout.comment.value != nil || workout.isUserModified.value), let firstActionView = firstActionView {
                     
                     self.contentView.addSubview(commentView)
                     
@@ -230,7 +209,7 @@ class WorkoutViewController: DetailViewController {
                     
                 } else {
                     
-                    lastView?.snp.makeConstraints({ (make) in
+                    lastView.snp.makeConstraints({ (make) in
                         make.bottom.equalTo((firstActionView ?? deleteView).snp.top).offset(-30)
                     })
                     

--- a/OutRun/Controllers/Workout/WorkoutViewController.swift
+++ b/OutRun/Controllers/Workout/WorkoutViewController.swift
@@ -30,7 +30,7 @@ class WorkoutViewController: DetailViewController {
         scrollView.backgroundColor = .backgroundColor
         return scrollView
     }()
-    
+
     let dateLabel = UILabel(
         textColor: .secondaryColor,
         font: UIFont.systemFont(ofSize: 14, weight: .bold)
@@ -68,7 +68,7 @@ class WorkoutViewController: DetailViewController {
         
         contentView.snp.makeConstraints { (make) in
             make.top.equalTo(headlineContainerView.snp.bottom)
-            make.left.right.bottom.equalTo(self.view)
+            make.bottom.equalTo(self.view)
         }
         
         self.view.addSubview(loadingView)
@@ -133,87 +133,64 @@ class WorkoutViewController: DetailViewController {
                         
                     }
                 }
-                
-                self.contentView.addSubview(distanceStatsView)
-                self.contentView.addSubview(timeStatsView)
-                self.contentView.addSubview(speedStatsView)
-                self.contentView.addSubview(heartRateStatsView)
-                self.contentView.addSubview(editView)
-                self.contentView.addSubview(deleteView)
-                
-                distanceStatsView.snp.makeConstraints { (make) in
-                    make.left.right.top.equalToSuperview()
+
+
+                let dynamicStackView = UIStackView()
+                dynamicStackView.alignment = .fill
+                dynamicStackView.spacing = 20
+                dynamicStackView.axis = .vertical
+                dynamicStackView.distribution = .equalSpacing
+
+                self.contentView.snp.makeConstraints { make in
+                    make.left.right.equalToSuperview()
+                }
+
+                self.contentView.addSubview(dynamicStackView)
+
+                dynamicStackView.snp.makeConstraints { make in
                     make.width.equalToSuperview()
                 }
-                timeStatsView.snp.makeConstraints { (make) in
-                    make.left.right.equalToSuperview()
-                    make.top.equalTo(distanceStatsView.snp.bottom).offset(20)
-                }
-                speedStatsView.snp.makeConstraints { (make) in
-                    make.left.right.equalToSuperview()
-                    make.top.equalTo(timeStatsView.snp.bottom).offset(20)
-                }
-                editView.snp.makeConstraints { (make) in
-                    make.left.equalToSuperview().offset(20)
-                    make.right.equalTo(deleteView.snp.left).offset(-20)
-                    make.width.equalTo(deleteView)
-                    make.bottom.equalTo(deleteView)
-                }
-                deleteView.snp.makeConstraints { (make) in
-                    make.right.equalToSuperview().offset(-20)
-                    make.bottom.equalToSuperview().offset(-20)
-                }
-                
-                var firstActionView: UIView?
-                var lastView: UIView = speedStatsView
-                
-                self.contentView.addSubview(appleHealthView)
-                
-                appleHealthView.snp.makeConstraints { (make) in
-                    make.right.left.equalToSuperview().inset(UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20))
-                    make.bottom.equalTo(deleteView.snp.top).offset(-20)
-                }
-                
-                firstActionView = appleHealthView
-                
-                var dynamicViews : [UIView] = []
-                
+
+                dynamicStackView.topAnchor.constraint(equalTo: self.contentView.topAnchor).isActive = true
+                dynamicStackView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor).isActive = true
+                dynamicStackView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor).isActive = true
+                dynamicStackView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor).isActive = true
+
+                dynamicStackView.addArrangedSubview(distanceStatsView)
+                dynamicStackView.addArrangedSubview(timeStatsView)
+                dynamicStackView.addArrangedSubview(speedStatsView)
+
                 if stats.hasEnergyValue {
-                    dynamicViews.append(energyStatsView)
+                    dynamicStackView.addArrangedSubview(energyStatsView)
                 }
-                if stats.hasHeartRateData {
-                    dynamicViews.append(heartRateStatsView)
-                }
+
+                dynamicStackView.addArrangedSubview(heartRateStatsView)
+
                 if stats.hasRouteSamples {
-                    dynamicViews.append(routeStatsView)
+                dynamicStackView.addArrangedSubview(routeStatsView)
                 }
 
-                for view in dynamicViews {
-                    self.contentView.addSubview(view)
-                    view.snp.makeConstraints { make in
-                        make.left.right.equalToSuperview()
-                        make.top.equalTo(lastView.snp.bottom).offset(20)
-                    }
-                    lastView = view
+
+                if (workout.comment.value != nil || workout.isUserModified.value) {
+                    dynamicStackView.addArrangedSubview(commentView)
+                }
+                dynamicStackView.addArrangedSubview(appleHealthView)
+
+
+                // Separate container for the action buttons
+                let actionViewContainer = UIStackView()
+
+
+                actionViewContainer.addArrangedSubview(editView)
+                actionViewContainer.addArrangedSubview(deleteView)
+                actionViewContainer.spacing = 20
+                actionViewContainer.axis = .horizontal
+
+                editView.snp.makeConstraints { (make) in
+                    make.width.equalTo(deleteView)
                 }
 
-                if (workout.comment.value != nil || workout.isUserModified.value), let firstActionView = firstActionView {
-                    
-                    self.contentView.addSubview(commentView)
-                    
-                    commentView.snp.makeConstraints({ (make) in
-                        make.bottom.equalTo(firstActionView.snp.top).offset(-30)
-                        make.top.equalTo(lastView.snp.bottom).offset(20)
-                        make.left.right.equalToSuperview()
-                    })
-                    
-                } else {
-                    
-                    lastView.snp.makeConstraints({ (make) in
-                        make.bottom.equalTo((firstActionView ?? deleteView).snp.top).offset(-30)
-                    })
-                    
-                }
+                dynamicStackView.addArrangedSubview(actionViewContainer)
             }
         }
     }

--- a/OutRun/Controllers/Workout/WorkoutViewController.swift
+++ b/OutRun/Controllers/Workout/WorkoutViewController.swift
@@ -167,7 +167,7 @@ class WorkoutViewController: DetailViewController {
                 dynamicStackView.addArrangedSubview(heartRateStatsView)
 
                 if stats.hasRouteSamples {
-                dynamicStackView.addArrangedSubview(routeStatsView)
+                    dynamicStackView.addArrangedSubview(routeStatsView)
                 }
 
 

--- a/OutRun/Models/Data/DataManager.swift
+++ b/OutRun/Models/Data/DataManager.swift
@@ -146,14 +146,6 @@ struct DataManager {
                 sample.workout .= workout
             }
             
-            for heartRate in heartRates {
-                let sample = transaction.create(Into<WorkoutHeartRateDataSample>())
-                sample.uuid .= heartRate.uuid ?? UUID()
-                sample.heartRate .= heartRate.heartRate
-                sample.timestamp .= heartRate.timestamp
-                sample.workout .= workout
-            }
-            
             return workout
             
         }) { (result) in
@@ -227,14 +219,6 @@ struct DataManager {
                     sample.verticalAccuracy .= location.verticalAccuracy
                     sample.speed .= location.speed
                     sample.direction .= location.direction
-                    sample.workout .= workout
-                }
-                
-                for heartRate in object.heartRates {
-                    let sample = transaction.create(Into<WorkoutHeartRateDataSample>())
-                    sample.uuid .= heartRate.uuid ?? UUID()
-                    sample.heartRate .= heartRate.heartRate
-                    sample.timestamp .= heartRate.timestamp
                     sample.workout .= workout
                 }
                 

--- a/OutRun/Models/Data/DataManager.swift
+++ b/OutRun/Models/Data/DataManager.swift
@@ -235,6 +235,7 @@ struct DataManager {
                     sample.uuid .= heartRate.uuid ?? UUID()
                     sample.heartRate .= heartRate.heartRate
                     sample.timestamp .= heartRate.timestamp
+                    sample.workout .= workout
                 }
                 
                 tempWorkouts.append(workout)

--- a/OutRun/Models/HealthKit/HealthStoreManager.swift
+++ b/OutRun/Models/HealthKit/HealthStoreManager.swift
@@ -43,10 +43,7 @@ enum HealthStoreManager {
         objectTypeDistanceCycling,
         objectTypeRouteType,
         objectTypeBodyMass,
-        // not fully implemented yet
-        /*
         objectTypeHeartRate,
-        */
         objectTypeStepCount
     ])
     

--- a/OutRun/Models/Workout/Stats/WorkoutStats.swift
+++ b/OutRun/Models/Workout/Stats/WorkoutStats.swift
@@ -31,7 +31,6 @@ class WorkoutStats {
     
     let hasWorkoutEvents: Bool
     let hasRouteSamples: Bool
-    let hasHeartRateData: Bool
     let hasEnergyValue: Bool
     
     // DISTANCE
@@ -75,7 +74,6 @@ class WorkoutStats {
         
         self.hasWorkoutEvents = !workout.workoutEvents.isEmpty
         self.hasRouteSamples = !workout.routeData.isEmpty
-        self.hasHeartRateData = !workout.heartRates.isEmpty
         self.hasEnergyValue = workout.burnedEnergy.value != nil
         
         self.distance = NSMeasurement(doubleValue: workout.distance.value, unit: UnitLength.meters)
@@ -157,30 +155,6 @@ class WorkoutStats {
                 },
                 completion: { (success, series) in
                     self.lastQueriedSpeedSeries = (success, series)
-                    completion(success, series)
-                }
-            )
-        }
-    }
-    
-    var lastQueriedHeartRateSeries: (Bool, WorkoutStatsSeries?)?
-    func queryHeartRates(completion: @escaping (Bool, WorkoutStatsSeries?) -> Void) {
-        DispatchQueue.main.async {
-            if let last = self.lastQueriedHeartRateSeries {
-                completion(last.0, last.1)
-                return
-            }
-            DataQueryManager.queryStatsSeries(
-                for: self.workout,
-                sampleType: WorkoutHeartRateDataSample.self,
-                dataPoint: { (workout, routeSample) -> (time: TimeInterval, value: Double, unit: Unit) in
-                    let time = workout.startDate.value.distance(to: routeSample.timestamp.value)
-                    let value = routeSample.heartRate.value
-                    let unit = UnitCount.count
-                    return (time: time, value: value, unit: unit)
-                },
-                completion: { (success, series) in
-                    self.lastQueriedHeartRateSeries = (success, series)
                     completion(success, series)
                 }
             )

--- a/OutRun/Support Files/Base.lproj/Localizable.strings
+++ b/OutRun/Support Files/Base.lproj/Localizable.strings
@@ -165,6 +165,8 @@
 "WorkoutStats.AverageSpeed" = "Avg. Speed";
 "WorkoutStats.TopSpeed" = "Top Speed";
 "WorkoutStats.SpeedOverTime" = "Speed Over Time";
+"WorkoutStats.HeartRate" = "Heart Rate";
+"WorkoutStats.HeartRateOverTime" = "Heart Rate Over Time";
 
 "WorkoutStats.BurnedEnergy" = "Burned Energy";
 "WorkoutStats.TotalEnergy" = "Total Energy";

--- a/OutRun/Support Files/de.lproj/Localizable.strings
+++ b/OutRun/Support Files/de.lproj/Localizable.strings
@@ -166,6 +166,8 @@
 "WorkoutStats.AverageSpeed" = "Durchschn.";
 "WorkoutStats.TopSpeed" = "Höchstgeschw.";
 "WorkoutStats.SpeedOverTime" = "Geschw. Über Zeit";
+"WorkoutStats.HeartRate" = "Herzfrequenz";
+"WorkoutStats.HeartRateOverTime" = "Herzfrequenz im Laufe der Zeit";
 
 "WorkoutStats.BurnedEnergy" = "Verbrannte Energie";
 "WorkoutStats.TotalEnergy" = "Gesamtenergie";

--- a/OutRun/Views/Data/LabelledDiagramView.swift
+++ b/OutRun/Views/Data/LabelledDiagramView.swift
@@ -123,7 +123,13 @@ class LabelledDiagramView: UIView, ChartViewDelegate, BigStatView {
             self.headlineLabel.text = self.title
             return
         }
-        
+
+
+        guard units.0.symbol != "" && units.1.symbol != "" else {
+            self.headlineLabel.text = self.title
+            return
+        }
+
         let formatter = MeasurementFormatter()
         formatter.unitOptions = .providedUnit
         let unitString = formatter.string(from: units.1) + "-" + formatter.string(from: units.0)

--- a/OutRun/Views/Stats/Detail/HeartRateStatsView.swift
+++ b/OutRun/Views/Stats/Detail/HeartRateStatsView.swift
@@ -24,33 +24,93 @@ import HealthKit
 class HeartRateStatsView: StatsView {
     
     
-    let heartRateChart: LabelledDiagramView?
-    
+    var heartRateChart: LabelledDiagramView?
+    let startDate: Date
+    let endDate: Date
+
     init(stats: WorkoutStats) {
-        
+        self.startDate = stats.startDate
+        self.endDate = stats.endDate
+
         var statViews = [StatView]()
-        
-        if stats.hasHeartRateData {
-            self.heartRateChart = LabelledDiagramView(title: LS("WorkoutStats.HeartRateOverTime"))
-            statViews.append(contentsOf: [heartRateChart!])
-        } else {
-            self.heartRateChart = nil
-        }
-        self.heartRateChart?.disableSelection()
-        
+        self.heartRateChart = LabelledDiagramView(title: LS("WorkoutStats.HeartRateOverTime"))
+        statViews.append(contentsOf: [self.heartRateChart!])
+
         super.init(title: LS("WorkoutStats.HeartRate"), statViews: statViews)
-        
-        if stats.hasHeartRateData {
-            stats.queryHeartRates { (success, series) in
-                if let series = series {
+
+        // View is hidden to start, so heart rate data is fetched async
+        self.isHidden = true
+        self.loadHeartRateData(stats:stats)
+    }
+
+    private func loadHeartRateData(stats: WorkoutStats) {
+        HealthQueryManager.getHeartRateSamples(startDate: self.startDate, endDate: self.endDate) { samples in
+            DispatchQueue.main.async {
+                let hasHeartRateData = !samples.isEmpty
+                self.heartRateChart?.disableSelection()
+
+                if hasHeartRateData {
+                    guard let series = HeartRateStatsView.generateWorkoutStatsSeries(heartRateSamples:samples, stats:stats)
+                    else {
+                        return
+                    }
+
                     let convertedSections = series.convertedForChartView(includeSamples: false, yUnit: UnitCount.count)
                     self.heartRateChart?.setData(for: convertedSections)
+                    self.isHidden = false
                 }
             }
+
         }
-        
     }
-    
+
+    private static func generateWorkoutStatsSeries(heartRateSamples: [TempWorkoutHeartRateDataSample], stats: WorkoutStats) -> WorkoutStatsSeries? {
+        var finishedSeriesSections: [WorkoutStatsSeriesSection] = []
+        var currentSamples: [TempWorkoutHeartRateDataSample] = []
+        var currentSectionData: [(x: NSMeasurement, y: NSMeasurement)] = []
+
+        func createAndAddSectionFromData() {
+            if !currentSectionData.isEmpty {
+
+                let section = WorkoutStatsSeriesSection(
+                    type:  .paused,
+                    data: currentSectionData,
+                    associatedDataSamples: currentSamples.compactMap({ (sample) -> TempWorkoutSeriesDataSampleType? in
+                        return sample
+
+                    })
+                )
+                finishedSeriesSections.append(section)
+
+                if let lastSample = currentSamples.last, let lastDataPoint = currentSectionData.last {
+                    currentSamples = []
+                    currentSectionData = []
+                    currentSamples.append(lastSample)
+                    currentSectionData.append(lastDataPoint)
+                } else {
+                    currentSamples = []
+                    currentSectionData = []
+                }
+
+            }
+        }
+
+        for (index, sample) in heartRateSamples.enumerated() {
+            let x = NSMeasurement(doubleValue: stats.startDate.distance(to: sample.timestamp), unit: UnitDuration.seconds)
+            let y = NSMeasurement(doubleValue: sample.heartRate, unit: UnitCount.count)
+            let dataObject = (x: x, y: y)
+
+            currentSectionData.append(dataObject)
+            currentSamples.append(sample)
+
+            if index == heartRateSamples.count - 1 {
+                createAndAddSectionFromData()
+            }
+        }
+
+        return WorkoutStatsSeries(sectioningType: .activeAndPaused, sections: finishedSeriesSections)
+    }
+
     required init?(coder aDecoder: NSCoder) {
         fatalError()
     }

--- a/OutRun/Views/Stats/Detail/HeartRateStatsView.swift
+++ b/OutRun/Views/Stats/Detail/HeartRateStatsView.swift
@@ -1,0 +1,57 @@
+//
+//  HeartRateStatsView.swift
+//
+//  OutRun
+//  Copyright (C) 2020 Tim Fraedrich <timfraedrich@icloud.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import UIKit
+import HealthKit
+
+class HeartRateStatsView: StatsView {
+    
+    
+    let heartRateChart: LabelledDiagramView?
+    
+    init(stats: WorkoutStats) {
+        
+        var statViews = [StatView]()
+        
+        if stats.hasHeartRateData {
+            self.heartRateChart = LabelledDiagramView(title: LS("WorkoutStats.HeartRateOverTime"))
+            statViews.append(contentsOf: [heartRateChart!])
+        } else {
+            self.heartRateChart = nil
+        }
+        self.heartRateChart?.disableSelection()
+        
+        super.init(title: LS("WorkoutStats.HeartRate"), statViews: statViews)
+        
+        if stats.hasHeartRateData {
+            stats.queryHeartRates { (success, series) in
+                if let series = series {
+                    let convertedSections = series.convertedForChartView(includeSamples: false, yUnit: UnitCount.count)
+                    self.heartRateChart?.setData(for: convertedSections)
+                }
+            }
+        }
+        
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError()
+    }
+}

--- a/OutRun/Views/Workout/WorkoutActionView.swift
+++ b/OutRun/Views/Workout/WorkoutActionView.swift
@@ -66,7 +66,9 @@ class WorkoutActionView: UIView {
         
         button.snp.makeConstraints { (make) in
             make.height.equalTo(50)
-            make.edges.equalToSuperview()
+            make.height.equalToSuperview()
+            make.left.equalTo(20)
+            make.right.equalTo(-20)
         }
         
     }


### PR DESCRIPTION
This adds a heart rate graph to the workout view, when available.

Heart rate data isn't actually captured as part of a workout, instead its recorded separately.
This means that for full heart rate tracking, we would need a companion watch app/extension.


~In the future, it may be better to rely on a query each time to fetch the heart rate information for displaying, rather than trying to store it.~ Updated the pull request to do this


A few other things to mention.
I think I've found a better solution for the PR #30. The issue was that steps was not always completing, resulting in the count never being updated.
Adding the completion handler in the right place for the steps import, seems to solve the issue.

Extracted out the querying for heart rate data, so that it doesn't actually rely on the workout. The query only really needs the start/end times. This should be useful as we can then use that data for displaying the heart rate graph, without relying on the stored samples.

I've added the German strings for `Heart Rate`, and `Heart Rate over time`, however, I did use Google Translate for this (as I don't speak German).

The Heart rate graph now relies on querying healthkit to get the data, so there is no need to store it within the app.
I'm not sure how to modify the core data models, so i've left that bit as it is.

The WorkoutViewController was getting a bit difficult to work with, as each view seemed to rely on the exact order of previous for layout. I've switched this to use a UIStackView, Which then means each subview is managed automatically, and in order. 
This also allows each individual view to control when it is shown/hidden via the isHidden property (UIStackView will auto arrange the views to manage)


Screenshots:

Below is a workout started in the Apple Workouts app on Apple Watch
![IMG_A25DE801D803-1](https://user-images.githubusercontent.com/879073/94998689-bb02c700-05ab-11eb-90cf-ae9e82fb2fb0.jpeg)


Below is a workout started with outrun.
![IMG_6C72DDA925B2-1](https://user-images.githubusercontent.com/879073/94998727-f4d3cd80-05ab-11eb-8b67-511f782f82c6.jpeg)


