### PR TITLE
update charts to DGCharts

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ platform :ios, '13.0'
 
 def ui_pods
   pod 'SnapKit'
-  pod 'Charts'
+  pod 'DGCharts'
   # pod 'JTAppleCalendar'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,42 +1,38 @@
 PODS:
   - Cache (6.0.0)
-  - Charts (4.1.0):
-    - Charts/Core (= 4.1.0)
-  - Charts/Core (4.1.0):
-    - SwiftAlgorithms (~> 1.0)
   - CombineExt (1.8.0)
   - CoreGPX (0.9.0)
   - CoreStore (9.0.0)
+  - DGCharts (5.1.0):
+    - DGCharts/Core (= 5.1.0)
+  - DGCharts/Core (5.1.0)
   - SnapKit (5.6.0)
-  - SwiftAlgorithms (1.0.0)
 
 DEPENDENCIES:
   - Cache
-  - Charts
   - CombineExt
   - CoreGPX
   - CoreStore
+  - DGCharts
   - SnapKit
 
 SPEC REPOS:
   trunk:
     - Cache
-    - Charts
     - CombineExt
     - CoreGPX
     - CoreStore
+    - DGCharts
     - SnapKit
-    - SwiftAlgorithms
 
 SPEC CHECKSUMS:
   Cache: 4ca7e00363fca5455f26534e5607634c820ffc2d
-  Charts: 354f86803d11d9c35de280587fef50d1af063978
   CombineExt: c4daa97ef75754d8ef319bd79edeef82652f3eea
   CoreGPX: 1381c8c47428c3a6bcac2f93d25ca1c5e3525811
   CoreStore: 1b820cd4d929750343479fd72585283a870973f4
+  DGCharts: 1c6daf585b6cfc78807af44ea690d357c410627f
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
-  SwiftAlgorithms: 38dda4731d19027fdeee1125f973111bf3386b53
 
-PODFILE CHECKSUM: b4f324d21339e6e93aad2dc22f76ec7b558b40a5
+PODFILE CHECKSUM: ff40e7b501e638bad38899eaa978a5ac2fd81008
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.10.1


### PR DESCRIPTION
Charts (in cocoa pods) has [changed names to DGCharts to not be confused with Apple Charts](https://github.com/ChartsOrg/Charts).

This PR changes the Podfile, so that `pod install` will work